### PR TITLE
fix: Immediately redraw on Vim

### DIFF
--- a/denops/scorpeon/highlight.ts
+++ b/denops/scorpeon/highlight.ts
@@ -36,6 +36,7 @@ export class Highlight {
       }
     }
     await decorate(this.denops, this.bufnr, decorations);
+    await this.denops.redraw(false);
   }
 
   getHighlightGroup(scopes: string[]): string | undefined {


### PR DESCRIPTION
The `denops.redraw()` is required to be called to change Vim's UI immediately. It does nothing on Neovim.